### PR TITLE
Generate same strings in Haskell as in C

### DIFF
--- a/hamming-haskell/src/Main.hs
+++ b/hamming-haskell/src/Main.hs
@@ -2,25 +2,28 @@ module Main where
 import qualified Data.Text as T
 import qualified Data.Text.Unsafe as TU
 import qualified Data.Text.Array as TA
-import Data.Text 
 import Data.Text.Internal (Text(Text))
+import Data.Char (chr)
 import Criterion.Main
 import Control.DeepSeq
 
+stringTo :: Int -> T.Text
+stringTo n = T.pack . map (chr . (`mod` 2^16)) $ [1..n]
+
 derpA ::T.Text
 derpB ::T.Text
-derpA = ((T.pack) . show) [1..1000000]
-derpB = ((T.pack) . show) [1..1000000]
+derpA = stringTo 1000000
+derpB = stringTo 1000000
 
 tenMilA ::T.Text
 tenMilB ::T.Text
-tenMilA = ((T.pack) . show) [1..10000000]
-tenMilB = ((T.pack) . show) [1..10000000]
+tenMilA = stringTo 10000000
+tenMilB = stringTo 10000000
 
 hundredMilA ::T.Text
 hundredMilB ::T.Text
-hundredMilA = ((T.pack) . show) [1..100000]
-hundredMilB = ((T.pack) . show) [1..100000]
+hundredMilA = stringTo 100000
+hundredMilB = stringTo 100000
 
 hamming :: T.Text -> T.Text -> Maybe Int
 hamming a b =


### PR DESCRIPTION
> In the C version, they initialise a string with consecutive numbers (0, 1, 2, and so on). So their 10,000 character string really is 10,000 characters. In the Haskell version, they generate a List [0, 1, 2, 3, ...], convert it to a String, and then pack that String to a Text. The final text will be something like "[0,1,2,3,4]" - the actual length of "[0,1,...,10000]" is 588,896 - so that accounts for part of the difference."

The Haskell code now generates the same strings as the C code. I experienced a speedup of factor 6-8 (the longer the string, the higher the speedup).